### PR TITLE
Bump base image and CI actions to latest

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,19 +18,19 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       -
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -38,7 +38,7 @@ jobs:
 
       -
         name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,9 +19,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/upload-pages-artifact@v4
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs
 
@@ -33,4 +33,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rabbitmq:4.1.1-management
+FROM rabbitmq:4.3.5-management
 
 LABEL maintainer="chrispeterson@fastmail.com"
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@ A docker image for administration of `RabbitMQ` (using `rabbitmqadmin` and/or `r
 
 The container contains the following:
 
-* [rabbitmqadmin](https://www.rabbitmq.com/management-cli.html)
+* [rabbitmqadmin](https://www.rabbitmq.com/docs/management-cli)
 * [rabbitmqctl](https://www.rabbitmq.com/rabbitmqctl.8.html)
 * [jq](https://stedolan.github.io/jq/) - command line JSON processor
-* [python](https://www.python.org/) - needed to support `rabbitmqadmin`
 
 The default `CMD` is `rmq` which invokes `rabbitmqctl` honoring [environment variables](#environment-variables).
 
@@ -39,7 +38,7 @@ docker run -e RABBIT_HOST=rabbitmqserver \
 ```sh
 docker run -e RABBIT_HOST=rabbitmqserver \
    -e RABBIT_USER=admin -e RABBIT_PASSWORD=p@ssw0rd \
-   ghcr.io/chris-peterson/rmq-cli:main rmqa export config.json
+   ghcr.io/chris-peterson/rmq-cli:main rmqa definitions export --file config.json
 ```
 
 #### Example: Show Overview
@@ -47,7 +46,7 @@ docker run -e RABBIT_HOST=rabbitmqserver \
 ```sh
 docker run -e RABBIT_HOST=rabbitmqserver \
    -e RABBIT_USER=admin -e RABBIT_PASSWORD=p@ssw0rd \
-   ghcr.io/chris-peterson/rmq-cli:main rmqa show overview --format=pretty_json
+   ghcr.io/chris-peterson/rmq-cli:main rmqa show overview
 ```
 
 #### Example: GitLab CI
@@ -66,7 +65,7 @@ variables:
 
 .snapshot:
   stage: snapshot
-  script: rmqa export $RABBIT_HOST.config
+  script: rmqa definitions export --file $RABBIT_HOST.config
   artifacts:
     paths:
     - $RABBIT_HOST.config
@@ -79,7 +78,7 @@ variables:
 
 .rollback:
   stage: rollback
-  script: rmqa import $RABBIT_HOST.config
+  script: rmqa definitions import --file $RABBIT_HOST.config
   when: manual
 
 snapshot:test:

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,12 +4,16 @@ A Docker image for administration of RabbitMQ using `rabbitmqadmin` and/or `rabb
 
 The container includes:
 
-* [rabbitmqadmin](https://www.rabbitmq.com/management-cli.html)
+* [rabbitmqadmin](https://www.rabbitmq.com/docs/management-cli)
 * [rabbitmqctl](https://www.rabbitmq.com/rabbitmqctl.8.html)
 * [jq](https://stedolan.github.io/jq/) — command line JSON processor
-* [python](https://www.python.org/) — needed to support `rabbitmqadmin`
 
 The default `CMD` is `rmq` which invokes `rabbitmqctl` honoring [environment variables](#environment-variables).
+
+`rabbitmqadmin` is v2, whose command syntax differs from v1: named arguments are
+`--snake-case` flags rather than `key=value`, and result sorting, column selection,
+and JSON/CSV output for most commands are gone. See the
+[breaking changes](https://github.com/rabbitmq/rabbitmqadmin-ng#breaking-or-potentially-breaking-changes).
 
 ## Environment Variables
 
@@ -35,7 +39,7 @@ docker run -e RABBIT_HOST=rabbitmqserver \
 ```bash
 docker run -e RABBIT_HOST=rabbitmqserver \
    -e RABBIT_USER=admin -e RABBIT_PASSWORD=p@ssw0rd \
-   ghcr.io/chris-peterson/rmq-cli:main rmqa export config.json
+   ghcr.io/chris-peterson/rmq-cli:main rmqa definitions export --file config.json
 ```
 
 ### Show Overview
@@ -43,7 +47,7 @@ docker run -e RABBIT_HOST=rabbitmqserver \
 ```bash
 docker run -e RABBIT_HOST=rabbitmqserver \
    -e RABBIT_USER=admin -e RABBIT_PASSWORD=p@ssw0rd \
-   ghcr.io/chris-peterson/rmq-cli:main rmqa show overview --format=pretty_json
+   ghcr.io/chris-peterson/rmq-cli:main rmqa show overview
 ```
 
 ### GitLab CI
@@ -62,7 +66,7 @@ variables:
 
 .snapshot:
   stage: snapshot
-  script: rmqa export $RABBIT_HOST.config
+  script: rmqa definitions export --file $RABBIT_HOST.config
   artifacts:
     paths:
     - $RABBIT_HOST.config
@@ -75,7 +79,7 @@ variables:
 
 .rollback:
   stage: rollback
-  script: rmqa import $RABBIT_HOST.config
+  script: rmqa definitions import --file $RABBIT_HOST.config
   when: manual
 
 snapshot:test:


### PR DESCRIPTION
## Context

rmq-cli is a Docker image that wraps RabbitMQ's own admin CLIs, so what the base image ships *is* the product. This moves it from `4.1.1-management` to `4.3.5-management`, and takes every action in both workflows to its latest major.

The base-image jump changes which `rabbitmqadmin` ships. Up to 4.1.5 the management image carried the deprecated Python v1; from 4.1.6 on it carries `rabbitmqadmin-ng` v2 (2.33.0 today). That reaches the outcome #6 asks for without the per-arch download or the `bin/rmqa` rewrite that issue planned: upstream already fetches and checksums the binary, and v2 kept `-H`/`-P`/`-u`/`-p` as globals ahead of the subcommand, which is the shape `bin/rmqa` already uses. Closes #6. The stale parts of that issue are corrected in place there.

## Review guide

**Start here.** The one line that changes what ships:

- [`Dockerfile:1`](https://github.com/chris-peterson/rmq-cli/pull/7/changes#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1) — `4.1.1-management` → `4.3.5-management`

**Then the docs the CLI swap invalidated.** v2 moved the definitions commands under a `definitions` group and dropped `--format` for everything but that group:

- [`README.md:41`](https://github.com/chris-peterson/rmq-cli/pull/7/changes#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R41) — `export config.json` → `definitions export --file config.json`; same shape at [`:68`](https://github.com/chris-peterson/rmq-cli/pull/7/changes#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R68) and [`:81`](https://github.com/chris-peterson/rmq-cli/pull/7/changes#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R81) in the GitLab CI snippet
- [`README.md:49`](https://github.com/chris-peterson/rmq-cli/pull/7/changes#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R49) — `show overview` loses `--format=pretty_json`
- [`docs/README.md:13`](https://github.com/chris-peterson/rmq-cli/pull/7/changes#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R13) — note naming v2 and linking its breaking-changes list, on the end-user-facing copy only

**Then the action bumps.** All Node 24 runtime bumps needing runner v2.327.1, which hosted `ubuntu-latest` satisfies. The inputs they drop aren't set here, and checkout v7's fork-checkout block applies to `pull_request_target` / `workflow_run`, which neither workflow uses:

- [`docker-publish.yml:21`](https://github.com/chris-peterson/rmq-cli/pull/7/changes#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R21) — checkout v4→v7, qemu v3→v4, buildx v3→v4, login v3→v4, build-push v6→v7
- [`docs.yml:22`](https://github.com/chris-peterson/rmq-cli/pull/7/changes#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cR22) — checkout v6→v7, upload-pages-artifact v4→v5, deploy-pages v4→v5. The two workflows had drifted apart on `actions/checkout`; they agree again

**Footnote.** The dropped `python` bullet in [`README.md`](https://github.com/chris-peterson/rmq-cli/pull/7/changes#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L10) — v2 is a standalone binary, and `python3` is absent from the built image.

## Approach & trade-offs

Inheriting v2 from the base image, rather than downloading it per #6's plan, couples the rabbitmqadmin version to the base-image tag: there's no independent pin, and a future base bump can move the CLI under us. In exchange there's no download-and-verify machinery to maintain, and upstream already `sha256sum --check`s the binary it installs.

## Validation

CI builds the image and never runs it, so each documented command was exercised against a live 4.3.5 node built from this Dockerfile.

| Command | Result |
| --- | --- |
| `rmqa list queues`, `rmqa show overview` | exit 0 |
| `rmqa definitions export --file`, `rmqa definitions import --file` | exit 0, round-trip |
| `rmq status`, `rmq list_queues`, `rmqdiag check_running` | exit 0 |
| `rmqa export config.json` (v1 form) | exit 2, unrecognized subcommand |
| `rmqa show overview --format=pretty_json` (v1 form) | exit 2, unexpected argument |

`rmq` and `rmqdiag` need long node names and a matching Erlang cookie on the server, as they did before this change; the rows above are against a node started with `RABBITMQ_USE_LONGNAME=true`.

Multi-arch is intact: the base image installs rabbitmqadmin for `amd64` and `arm64` only, which is exactly the matrix this workflow builds, and both platforms build green.

`docs.yml` is unexercised — it triggers only on `docs/**` pushes to `main`, so its three action bumps land untested. A `workflow_dispatch` on `main` after merge is the cheap check.
