### PR TITLE
Publish releases from semver tags

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+
+updates:
+  # tracks the rabbitmq:*-management base image, which is what the git tag mirrors
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      # one PR per sweep rather than seven; these move together in practice
+      actions:
+        patterns: ['*']

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,18 +2,28 @@ name: Docker
 
 on:
   push:
+    branches: [main]
+    tags: ['[0-9]+.[0-9]+.[0-9]+*']
     paths-ignore:
       - 'docs/**'
       - '.github/workflows/docs.yml'
+  pull_request:
+  workflow_dispatch:
 
-env:
-  IMAGE_NAME: rmq-cli
-  VERSION: ${{ github.ref_name }}
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+  attestations: write
 
 jobs:
   docker:
 
     runs-on: ubuntu-latest
+
+    outputs:
+      base: ${{ steps.base.outputs.image }}
+      tags: ${{ steps.meta.outputs.tags }}
 
     steps:
       -
@@ -29,7 +39,13 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       -
+        name: Read base image from Dockerfile
+        id: base
+        run: echo "image=$(sed -n '1s/^FROM //p' Dockerfile)" >> "$GITHUB_OUTPUT"
+
+      -
         name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -37,11 +53,105 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       -
+        name: Compute image tags
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=main,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+          labels: |
+            org.opencontainers.image.base.name=${{ steps.base.outputs.image }}
+
+      -
         name: Build and push
+        id: push
         uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{github.actor}}/${{env.IMAGE_NAME}}:${{env.VERSION}}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          sbom: ${{ github.event_name != 'pull_request' }}
+
+      -
+        name: Install syft
+        if: github.event_name != 'pull_request'
+        uses: anchore/sbom-action/download-syft@v0.24.0
+
+      -
+        name: Generate per-platform SBOMs
+        if: github.event_name != 'pull_request'
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}@${{ steps.push.outputs.digest }}
+        run: |
+          syft "$IMAGE" --platform linux/amd64 -o spdx-json=sbom-amd64.spdx.json
+          syft "$IMAGE" --platform linux/arm64 -o spdx-json=sbom-arm64.spdx.json
+
+      -
+        name: Attest build provenance
+        if: github.event_name != 'pull_request'
+        uses: actions/attest@v4
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+          create-storage-record: false
+
+      -
+        name: Attest the amd64 SBOM
+        if: github.event_name != 'pull_request'
+        uses: actions/attest@v4
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          sbom-path: sbom-amd64.spdx.json
+          push-to-registry: true
+          create-storage-record: false
+
+      -
+        name: Attest the arm64 SBOM
+        if: github.event_name != 'pull_request'
+        uses: actions/attest@v4
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          sbom-path: sbom-arm64.spdx.json
+          push-to-registry: true
+          create-storage-record: false
+
+  release:
+
+    needs: docker
+    if: startsWith(github.ref, 'refs/tags/')
+
+    runs-on: ubuntu-latest
+
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      -
+        name: Assemble release notes
+        env:
+          BASE: ${{ needs.docker.outputs.base }}
+          TAGS: ${{ needs.docker.outputs.tags }}
+        run: |
+          git tag -l --format='%(contents)' "$GITHUB_REF_NAME" > notes.md
+          printf '\n---\n\nBuilt from `%s`.\n\nPublished tags:\n\n```\n%s\n```\n' \
+            "$BASE" "$TAGS" >> notes.md
+
+      -
+        name: Publish the release
+        uses: softprops/action-gh-release@v3
+        with:
+          generate_release_notes: false
+          body_path: notes.md

--- a/docs/README.md
+++ b/docs/README.md
@@ -100,3 +100,23 @@ rollback:test:
   variables:
     RABBIT_HOST: test-rabbitmqserver
 ```
+
+## Verifying the image
+
+Published images carry a [SLSA build provenance](https://slsa.dev/spec/v1.0/provenance)
+attestation and per-platform SBOMs, signed by Sigstore during the build. The
+provenance binds the image digest to the workflow run that produced it, so you can
+confirm an image came from this repository rather than from someone who pushed a
+similarly-named tag.
+
+```bash
+gh attestation verify oci://ghcr.io/chris-peterson/rmq-cli:4.3.5 \
+   --repo chris-peterson/rmq-cli
+```
+
+To read the SBOM instead of verifying the signature:
+
+```bash
+docker buildx imagetools inspect ghcr.io/chris-peterson/rmq-cli:4.3.5 \
+   --format '{{ json .SBOM }}'
+```


### PR DESCRIPTION
## Context

rmq-cli publishes one artifact: a Docker image on ghcr. Releasing it was never designed — `VERSION` was `github.ref_name`, so pushing a git tag *happened* to produce an image named after the tag. Everything around that was accidental too: every feature-branch push published a junk tag beside it (#7 created one), no path through the workflow ever wrote `latest`, so pulling the image untagged resolved to nothing, and a tag left no GitHub Release behind. Nor could a consumer tell an image built here from one someone else pushed under a similar name.

The repo's convention is that the git tag mirrors the RabbitMQ base image version — tag `4.1.1` sits on the commit whose Dockerfile reads `FROM rabbitmq:4.1.1-management`. Nothing enforced that pairing and it went stale across four minor releases before #7 caught it, which is why Dependabot now watches the Dockerfile.

## Review guide

**Start here** — what each kind of push now publishes:

- [`docker-publish.yml:62`](https://github.com/chris-peterson/rmq-cli/pull/8/changes#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R62) — the tag set. A semver tag gets `X.Y.Z`, `X.Y`, and `latest`; `main` keeps `:main`, which is the tag every README example tells people to pull
- [`:5`](https://github.com/chris-peterson/rmq-cli/pull/8/changes#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R5) — the trigger narrows from every branch to `main` plus semver tags, with `pull_request` added
- [`:77`](https://github.com/chris-peterson/rmq-cli/pull/8/changes#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R77) — PRs build both platforms and push nothing. That pairing is what stops the branch tags without giving up the build as a gate

**Then the signing** ([`:97`](https://github.com/chris-peterson/rmq-cli/pull/8/changes#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R97)). The image already carried BuildKit provenance — build-push-action passes `--attest type=provenance,mode=max` on every push without being asked, and you can read it off `:main` today. What it lacked was a signature checkable from outside the build. `actions/attest` binds the image digest to the workflow run with a short-lived Sigstore certificate.

- [`:80`](https://github.com/chris-peterson/rmq-cli/pull/8/changes#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R80) and [`:83`](https://github.com/chris-peterson/rmq-cli/pull/8/changes#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R83) — SBOMs, which the image had none of. `sbom: true` adds BuildKit's per-platform ones to the index; syft produces files that get their own signed attestations at [`:107`](https://github.com/chris-peterson/rmq-cli/pull/8/changes#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R107)
- [`:13`](https://github.com/chris-peterson/rmq-cli/pull/8/changes#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R13) — `id-token: write` for the Sigstore OIDC exchange, `attestations: write` for GitHub's attestations API
- [`docs/README.md:104`](https://github.com/chris-peterson/rmq-cli/pull/8/changes#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R104) — the verify commands, on the end-user-facing copy. An attestation nobody can check is decoration

**Then the release job** ([`:128`](https://github.com/chris-peterson/rmq-cli/pull/8/changes#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R128)), which fires only on a tag. Its body is the annotated tag's own contents plus a footer naming the base image and the pushed tags. `/anchor:release` writes notes into the tag it pushes, so the prose exists before the job runs; a lightweight tag yields the footer alone.

**Then the image path** ([`:60`](https://github.com/chris-peterson/rmq-cli/pull/8/changes#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R60)) — `github.actor` becomes `github.repository`. Both resolve to `chris-peterson/rmq-cli` when a person pushes, but `actor` is whoever triggered the run, so the Dependabot config below would have aimed builds at `ghcr.io/dependabot[bot]/rmq-cli`.

**Footnote:** [`dependabot.yml`](https://github.com/chris-peterson/rmq-cli/pull/8/changes#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1) — the Dockerfile base image, and the actions grouped so a sweep arrives as one PR rather than seven.

## Approach & trade-offs

**`create-storage-record: false`, and `subject-name` without a tag.** Storage records only work for organization-owned repositories and this one belongs to a user account. The subject is the digest; naming a tag would make it ambiguous the moment the tag moved.

**SBOMs are signed per platform, not once.** syft resolves a multi-arch index to a single platform, so a single scan would describe amd64 while appearing to cover the image. Two scans and two attestations cost a little duplication and keep the attestation honest about what it read.

**`generate_release_notes` stays off.** It lists unrelated merged PRs, and that body is permanent once anything downstream proxies it into a changelog. Taking the tag annotation instead means publishing prose a person wrote, at the cost of a near-empty body if someone hand-pushes a lightweight tag.

**`paths-ignore` still excludes `docs/**`, and GitHub applies path filters to tag pushes.** So tagging a docs-only commit skips the build and no release appears; `workflow_dispatch` is the way out. The alternative was dropping the docs exclusion 273eca4 added deliberately.

## Validation

What's checkable before merge, against the `:main` image published from the current workflow:

| Check | Result |
| --- | --- |
| `imagetools inspect --format '{{ json .Provenance }}'` | populated for `linux/amd64` and `linux/arm64` — BuildKit provenance is already there |
| `imagetools inspect --format '{{ json .SBOM }}'` | `{}` — the gap `sbom: true` closes |
| `gh attestation verify oci://…:main --repo chris-peterson/rmq-cli` | `HTTP 404` on the attestations API — the gap `actions/attest` closes |

The success cases can't be produced until this merges and a push runs, so the docs carry the commands without sample output for now. The release job and the semver tag set are likewise unexercised — nothing short of a real tag runs them, and the first one after merge is `4.3.5`, since `main`'s Dockerfile is there while the newest tag is still `4.1.1`.
