### PR TITLE
Publish only version tags, built per architecture

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,36 @@
+name: Docker build
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v7
+
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      -
+        name: Build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,12 +2,7 @@ name: Docker
 
 on:
   push:
-    branches: [main]
     tags: ['[0-9]+.[0-9]+.[0-9]+*']
-    paths-ignore:
-      - 'docs/**'
-      - '.github/workflows/docs.yml'
-  pull_request:
   workflow_dispatch:
 
 permissions:
@@ -16,14 +11,24 @@ permissions:
   id-token: write
   attestations: write
 
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+
 jobs:
-  docker:
+  build:
 
-    runs-on: ubuntu-latest
+    if: github.ref_type == 'tag'
 
-    outputs:
-      base: ${{ steps.base.outputs.image }}
-      tags: ${{ steps.meta.outputs.tags }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            arch: amd64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+
+    runs-on: ${{ matrix.runner }}
 
     steps:
       -
@@ -31,12 +36,70 @@ jobs:
         uses: actions/checkout@v7
 
       -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        name: Read base image from Dockerfile
+        id: base
+        run: echo "image=$(sed -n '1s/^FROM //p' Dockerfile)" >> "$GITHUB_OUTPUT"
 
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      -
+        name: Build and push by digest
+        id: push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/${{ matrix.arch }}
+          sbom: true
+          labels: org.opencontainers.image.base.name=${{ steps.base.outputs.image }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      -
+        name: Install syft
+        uses: anchore/sbom-action/download-syft@v0.24.0
+
+      -
+        name: Generate the SBOM
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          mkdir -p /tmp/out
+          syft "${IMAGE}@${DIGEST}" -o spdx-json=/tmp/out/sbom-${{ matrix.arch }}.spdx.json
+          echo "${DIGEST#sha256:}" > /tmp/out/digest-${{ matrix.arch }}
+
+      -
+        name: Upload the digest and SBOM
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-${{ matrix.arch }}
+          path: /tmp/out/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+
+    needs: build
+
+    runs-on: ubuntu-latest
+
+    outputs:
+      digest: ${{ steps.index.outputs.digest }}
+      tags: ${{ steps.meta.outputs.tags }}
+      base: ${{ steps.base.outputs.image }}
+
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v7
 
       -
         name: Read base image from Dockerfile
@@ -44,8 +107,19 @@ jobs:
         run: echo "image=$(sed -n '1s/^FROM //p' Dockerfile)" >> "$GITHUB_OUTPUT"
 
       -
+        name: Download the per-architecture builds
+        uses: actions/download-artifact@v8
+        with:
+          pattern: build-*
+          merge-multiple: true
+          path: /tmp/out
+
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      -
         name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -57,78 +131,83 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ${{ env.IMAGE }}
+          flavor: latest=false
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=${{ github.ref_name }},enable=${{ startsWith(github.ref, 'refs/tags/') }}
-            type=raw,value=main,enable={{is_default_branch}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
-          labels: |
-            org.opencontainers.image.base.name=${{ steps.base.outputs.image }}
+            type=raw,value=${{ github.ref_name }}
 
       -
-        name: Build and push
-        id: push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          sbom: ${{ github.event_name != 'pull_request' }}
-
-      -
-        name: Install syft
-        if: github.event_name != 'pull_request'
-        uses: anchore/sbom-action/download-syft@v0.24.0
-
-      -
-        name: Generate per-platform SBOMs
-        if: github.event_name != 'pull_request'
-        env:
-          IMAGE: ghcr.io/${{ github.repository }}@${{ steps.push.outputs.digest }}
+        name: Assemble the manifest list
         run: |
-          syft "$IMAGE" --platform linux/amd64 -o spdx-json=sbom-amd64.spdx.json
-          syft "$IMAGE" --platform linux/arm64 -o spdx-json=sbom-arm64.spdx.json
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(for f in /tmp/out/digest-*; do printf '%s@sha256:%s ' "$IMAGE" "$(cat "$f")"; done)
+
+      -
+        name: Read the index digest
+        id: index
+        run: |
+          digest=$(docker buildx imagetools inspect "${IMAGE}:${{ steps.meta.outputs.version }}" \
+            --format '{{ json .Manifest }}' | jq -r .digest)
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+  attest:
+
+    needs: merge
+
+    runs-on: ubuntu-latest
+
+    steps:
+      -
+        name: Download the SBOMs
+        uses: actions/download-artifact@v8
+        with:
+          pattern: build-*
+          merge-multiple: true
+          path: /tmp/out
+
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       -
         name: Attest build provenance
-        if: github.event_name != 'pull_request'
         uses: actions/attest@v4
         with:
-          subject-name: ghcr.io/${{ github.repository }}
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ needs.merge.outputs.digest }}
           push-to-registry: true
           create-storage-record: false
 
       -
         name: Attest the amd64 SBOM
-        if: github.event_name != 'pull_request'
         uses: actions/attest@v4
         with:
-          subject-name: ghcr.io/${{ github.repository }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          sbom-path: sbom-amd64.spdx.json
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ needs.merge.outputs.digest }}
+          sbom-path: /tmp/out/sbom-amd64.spdx.json
           push-to-registry: true
           create-storage-record: false
 
       -
         name: Attest the arm64 SBOM
-        if: github.event_name != 'pull_request'
         uses: actions/attest@v4
         with:
-          subject-name: ghcr.io/${{ github.repository }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          sbom-path: sbom-arm64.spdx.json
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ needs.merge.outputs.digest }}
+          sbom-path: /tmp/out/sbom-arm64.spdx.json
           push-to-registry: true
           create-storage-record: false
 
   release:
 
-    needs: docker
-    if: startsWith(github.ref, 'refs/tags/')
+    needs: [merge, attest]
 
     runs-on: ubuntu-latest
 
@@ -142,10 +221,13 @@ jobs:
       -
         name: Assemble release notes
         env:
-          BASE: ${{ needs.docker.outputs.base }}
-          TAGS: ${{ needs.docker.outputs.tags }}
+          BASE: ${{ needs.merge.outputs.base }}
+          TAGS: ${{ needs.merge.outputs.tags }}
         run: |
-          git tag -l --format='%(contents)' "$GITHUB_REF_NAME" > notes.md
+          : > notes.md
+          if [ "$(git cat-file -t "$GITHUB_REF_NAME")" = tag ]; then
+            git tag -l --format='%(contents)' "$GITHUB_REF_NAME" > notes.md
+          fi
           printf '\n---\n\nBuilt from `%s`.\n\nPublished tags:\n\n```\n%s\n```\n' \
             "$BASE" "$TAGS" >> notes.md
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ The container contains the following:
 
 The default `CMD` is `rmq` which invokes `rabbitmqctl` honoring [environment variables](#environment-variables).
 
+Images are tagged `X.Y.Z` and `X.Y`, tracking the RabbitMQ base image version. Pin
+`X.Y` for patch updates within a minor line. Every image is signed with SLSA
+provenance and ships an SBOM per platform — see
+[tags and verification](https://chris-peterson.github.io/rmq-cli/#/?id=image-tags).
+
 ### Environment Variables
 
 A few environment variables can be provided:
@@ -30,7 +35,7 @@ The following are some common examples for how you might use the container.
 ```sh
 docker run -e RABBIT_HOST=rabbitmqserver \
    -e RABBIT_USER=admin -e RABBIT_PASSWORD=p@ssw0rd \
-   ghcr.io/chris-peterson/rmq-cli:main rmqa list queues
+   ghcr.io/chris-peterson/rmq-cli:4.3 rmqa list queues
 ```
 
 #### Example: Export Configuration
@@ -38,7 +43,7 @@ docker run -e RABBIT_HOST=rabbitmqserver \
 ```sh
 docker run -e RABBIT_HOST=rabbitmqserver \
    -e RABBIT_USER=admin -e RABBIT_PASSWORD=p@ssw0rd \
-   ghcr.io/chris-peterson/rmq-cli:main rmqa definitions export --file config.json
+   ghcr.io/chris-peterson/rmq-cli:4.3 rmqa definitions export --file config.json
 ```
 
 #### Example: Show Overview
@@ -46,7 +51,7 @@ docker run -e RABBIT_HOST=rabbitmqserver \
 ```sh
 docker run -e RABBIT_HOST=rabbitmqserver \
    -e RABBIT_USER=admin -e RABBIT_PASSWORD=p@ssw0rd \
-   ghcr.io/chris-peterson/rmq-cli:main rmqa show overview
+   ghcr.io/chris-peterson/rmq-cli:4.3 rmqa show overview
 ```
 
 #### Example: GitLab CI
@@ -57,7 +62,7 @@ stages:
 - deploy
 - rollback
 
-image: ghcr.io/chris-peterson/rmq-cli:main
+image: ghcr.io/chris-peterson/rmq-cli:4.3
 
 variables:
   RABBIT_USER: admin

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ and JSON/CSV output for most commands are gone. See the
 ```bash
 docker run -e RABBIT_HOST=rabbitmqserver \
    -e RABBIT_USER=admin -e RABBIT_PASSWORD=p@ssw0rd \
-   ghcr.io/chris-peterson/rmq-cli:main rmqa list queues
+   ghcr.io/chris-peterson/rmq-cli:4.3 rmqa list queues
 ```
 
 ### Export Configuration
@@ -39,7 +39,7 @@ docker run -e RABBIT_HOST=rabbitmqserver \
 ```bash
 docker run -e RABBIT_HOST=rabbitmqserver \
    -e RABBIT_USER=admin -e RABBIT_PASSWORD=p@ssw0rd \
-   ghcr.io/chris-peterson/rmq-cli:main rmqa definitions export --file config.json
+   ghcr.io/chris-peterson/rmq-cli:4.3 rmqa definitions export --file config.json
 ```
 
 ### Show Overview
@@ -47,7 +47,7 @@ docker run -e RABBIT_HOST=rabbitmqserver \
 ```bash
 docker run -e RABBIT_HOST=rabbitmqserver \
    -e RABBIT_USER=admin -e RABBIT_PASSWORD=p@ssw0rd \
-   ghcr.io/chris-peterson/rmq-cli:main rmqa show overview
+   ghcr.io/chris-peterson/rmq-cli:4.3 rmqa show overview
 ```
 
 ### GitLab CI
@@ -58,7 +58,7 @@ stages:
 - deploy
 - rollback
 
-image: ghcr.io/chris-peterson/rmq-cli:main
+image: ghcr.io/chris-peterson/rmq-cli:4.3
 
 variables:
   RABBIT_USER: admin
@@ -101,6 +101,28 @@ rollback:test:
     RABBIT_HOST: test-rabbitmqserver
 ```
 
+## Image tags
+
+Tags follow the RabbitMQ base image version, in two forms:
+
+| Tag | Moves? | Use it when |
+| --- | --- | --- |
+| `4.3` | to the newest `4.3.x` | **recommended** — patch updates within a minor line, so the `rabbitmqadmin` CLI grammar stays put |
+| `4.3.5` | never | you need a byte-identical image on every pull |
+
+### Older versions
+
+Still resolvable, no longer built:
+
+| Tag | RabbitMQ | Notes |
+| --- | --- | --- |
+| `4.1.1` | 4.1.1 | last release before the base image switched to `rabbitmqadmin` v2 |
+| `4.x` | 4.1.1 | no longer produced, in favor of the `X.Y` and `X.Y.Z` forms [above](#image-tags) |
+| `3.13` | 3.13.3 | RabbitMQ 3.x, `rabbitmqadmin` v1 grammar |
+
+`4.1.1` and earlier ship the Python `rabbitmqadmin` v1, where definitions export is
+`export <file>` rather than `definitions export --file <file>`.
+
 ## Verifying the image
 
 Published images carry a [SLSA build provenance](https://slsa.dev/spec/v1.0/provenance)
@@ -114,9 +136,63 @@ gh attestation verify oci://ghcr.io/chris-peterson/rmq-cli:4.3.5 \
    --repo chris-peterson/rmq-cli
 ```
 
-To read the SBOM instead of verifying the signature:
+```text
+Loaded digest sha256:a0fb14f79d4bfc9b78c36c8eb0f2a5d81c37317e128be8768bf7ccaa696beb93 for oci://ghcr.io/chris-peterson/rmq-cli:4.3.5
+Loaded 1 attestation from GitHub API
+
+The following policy criteria will be enforced:
+- Predicate type must match:................ https://slsa.dev/provenance/v1
+- Source Repository Owner URI must match:... https://github.com/chris-peterson
+- Source Repository URI must match:......... https://github.com/chris-peterson/rmq-cli
+- Subject Alternative Name must match regex: (?i)^https://github\.com/chris-peterson/rmq-cli/
+- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
+
+✓ Verification succeeded!
+
+The following 1 attestation matched the policy criteria
+
+- Attestation #1
+  - Build repo:..... chris-peterson/rmq-cli
+  - Build workflow:. .github/workflows/docker-publish.yml@refs/tags/4.3.5
+  - Signer repo:.... chris-peterson/rmq-cli
+  - Signer workflow: .github/workflows/docker-publish.yml@refs/tags/4.3.5
+```
+
+**In a pipeline, gate on the exit code, not the output.** That report is only
+printed to a terminal; with stdout redirected or piped, `gh attestation verify`
+prints nothing at all and signals solely through its exit status. A silent success
+is easily misread as a failed command:
+
+```bash
+if gh attestation verify oci://ghcr.io/chris-peterson/rmq-cli:4.3 \
+     --repo chris-peterson/rmq-cli >/dev/null 2>&1; then
+   echo "provenance ok"
+fi
+```
+
+## Reading the SBOM
+
+Each image carries an SPDX SBOM per platform, so you can answer "does this
+CVE affect me" without pulling and scanning the image yourself:
 
 ```bash
 docker buildx imagetools inspect ghcr.io/chris-peterson/rmq-cli:4.3.5 \
-   --format '{{ json .SBOM }}'
+   --format '{{ json .SBOM }}' \
+   | jq -r '."linux/amd64".SPDX.packages[] | "\(.name) \(.versionInfo)"' | sort
 ```
+
+```text
+adduser 3.137ubuntu1
+apt 2.8.3
+base-files 13ubuntu10.4
+base-passwd 3.6.3build1
+bash 5.2.21-2ubuntu4
+bsdutils 1:2.39.3-9ubuntu6.5
+ca-certificates 20260601~24.04.1
+coreutils 9.4-3ubuntu6.2
+...
+```
+
+Swap `linux/amd64` for `linux/arm64` to read the other platform; both carry 124
+packages for 4.3.5. The signed SBOM attestations are separate from these, one per
+platform, and are what `gh attestation verify` checks.


### PR DESCRIPTION
## Context

rmq-cli publishes one artifact: a Docker image on ghcr, tagged to track the RabbitMQ base image it wraps. Cutting 4.3.5 — the first release through the tag-driven workflow — surfaced two bugs and one choice worth reversing.

The choice is `latest` and `:main`. Both float across major versions, and this repo just paid for that: the base image's `rabbitmqadmin` v1-to-v2 swap turned `export <file>` into `definitions export --file <file>`, a break that reaches anyone on a floating tag with no version change on their side. The registry now receives `X.Y.Z` and `X.Y` only, which makes a tag push the sole publishing event — and that is what splits the workflow in two.

## Review guide

**Start here** — the two bugs 4.3.5 exposed:

- [`docker-publish.yml:135`](https://github.com/chris-peterson/rmq-cli/pull/9/changes#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R135) — `flavor: latest=false`. `latest` was published twice, because metadata-action's `type=semver` already implies `latest=auto` and the explicit `type=raw,value=latest` duplicated it. Deleting the raw line alone would not have removed the tag
- [`docker-publish.yml:228`](https://github.com/chris-peterson/rmq-cli/pull/9/changes#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R228) — the notes read `%(contents)` only when `git cat-file -t` says the ref is a tag object. On a lightweight tag `%(contents)` falls back to the tagged commit's message, so 4.3.5's release opened with `Merge pull request #8 from chris-peterson/release-publishing`

**Then the split.** Guarding one workflow took seven copies of the same is-this-a-tag condition:

- [`docker-build.yml:13`](https://github.com/chris-peterson/rmq-cli/pull/9/changes#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82R13) — the gate for `main` and pull requests. Builds only; pushes nothing
- [`docker-publish.yml:18`](https://github.com/chris-peterson/rmq-cli/pull/9/changes#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R18) — tags only, with one job-level guard left because `workflow_dispatch` can target a branch, where there is no version to publish under

**Then how both sides build.** One architecture per native runner, the same matrix in each file ([gate](https://github.com/chris-peterson/rmq-cli/pull/9/changes#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82R18), [publish](https://github.com/chris-peterson/rmq-cli/pull/9/changes#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R25)) — a gate that builds differently from the release is not testing the release. Publishing then adds three jobs the gate has no use for:

- [`:64`](https://github.com/chris-peterson/rmq-cli/pull/9/changes#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R64) — each arch pushed by digest, untagged
- [`merge:88`](https://github.com/chris-peterson/rmq-cli/pull/9/changes#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R88) → [`:142`](https://github.com/chris-peterson/rmq-cli/pull/9/changes#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R142) — `imagetools create` assembles those digests into one index and reads back its digest
- [`attest:156`](https://github.com/chris-peterson/rmq-cli/pull/9/changes#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R156) — provenance and both SBOMs bind to the **index** digest, not to either single-architecture build

**Then the docs:**

- [`docs/README.md:104`](https://github.com/chris-peterson/rmq-cli/pull/9/changes#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R104) — the tag table, `4.3` first as the recommended pin, and an [Older versions](https://github.com/chris-peterson/rmq-cli/pull/9/changes#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R113) table. That table is built from probing ghcr, not from the branch names: `4.1` and `3.x` don't exist; `4.1.1`, `4.x` and `3.13` do
- [`README.md:38`](https://github.com/chris-peterson/rmq-cli/pull/9/changes#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38) — every example moves off `:main` to `:4.3`

## Approach & trade-offs

**`:main` keeps resolving.** It was published up to 4.3.5 and stays in the registry, so nobody's pull 404s; it receives no further updates. That's a soft break for anyone following the old README rather than a hard one, and it's why the docs repoint rather than the tag being deleted.

**One action is pinned to an exact patch.** `anchore/sbom-action/download-syft@v0.24.0` is pre-1.0, so a `v0` pin would float across breaking changes. It's the only action here that won't pick up fixes on its own; Dependabot is what moves it. Every other action floats on its major, and all twelve are at their latest major as of this PR.

## Validation

Every command the docs tell a user to run was run, against the published `:4.3` image and a live RabbitMQ 4.3.5 node using the credentials the examples show:

| Documented command | Exit |
| --- | --- |
| `rmqa list queues` | 0 |
| `rmqa definitions export --file config.json` | 0 |
| `rmqa show overview` | 0 |
| GitLab CI snapshot → rollback round-trip | 0 |
| default `CMD` | 0, prints `rabbitmqctl` usage |

The native-runner matrix is proven by this PR's own gate run — both legs green, `build (ubuntu-24.04-arm)` on a hosted arm runner and `build (ubuntu-latest)` on amd64.

One thing this PR cannot settle, waiting on the next tagged release: **whether buildkit's embedded SBOM survives `imagetools create` into the index.** The `.SBOM` sample in the docs is real output captured from `4.3.5`, which the previous single-job pipeline built; under per-arch-then-merge it is untested, and a local registry test to settle it ran out of disk. If it comes back empty, that docs block is a one-line fix. The signed SBOM attestations are unaffected either way, since `actions/attest` binds them independently of buildkit.
